### PR TITLE
Add PDM update automation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@ Then open http://localhost:8000/ in your browser.
 4. Commit the change in GitHub and practice the basic workflow.
 
 This is intentionally simple so you can focus on the GitHub and Codex workflow instead of complex code.
+
+## Repeating the PDM data update process
+
+For regular updates, the simplest repeatable approach is to run the helper script instead of editing `PDM_Data.txt` by hand. The script validates the date and numeric values, updates an existing date if you rerun it, keeps the data sorted, and writes the row in the format the chart already reads.
+
+Example:
+
+```bash
+python scripts/add_pdm_entry.py 2026-06-05 0.6720 0.7010
+```
+
+Then commit and push the updated data file:
+
+```bash
+git status
+git add PDM_Data.txt
+git commit -m "Update PDM data"
+git push
+```
+
+This is a good first automation because it stays transparent: you can run it whenever you have new data, inspect the file before committing, and still use the normal GitHub workflow. If the data eventually comes from a spreadsheet, database, or API, the same script can be extended to read from that source and can also be scheduled with a cron job, Windows Task Scheduler, or GitHub Actions.

--- a/scripts/add_pdm_entry.py
+++ b/scripts/add_pdm_entry.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Add or update one PDM data row in PDM_Data.txt.
+
+Usage:
+    python scripts/add_pdm_entry.py 2026-06-05 0.6720 0.7010
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_FILE = REPO_ROOT / "PDM_Data.txt"
+EXPECTED_HEADER = ["date", "fraction_time_elapsed", "fraction_PDM_spent"]
+
+
+@dataclass(frozen=True)
+class PdmRow:
+    date: str
+    fraction_time_elapsed: float
+    fraction_pdm_spent: float
+
+    def as_csv_row(self) -> list[str]:
+        return [
+            self.date,
+            f"{self.fraction_time_elapsed:.4f}",
+            f"{self.fraction_pdm_spent:.4f}",
+        ]
+
+
+def parse_fraction(value: str, field_name: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"{field_name} must be a number between 0 and 1.") from error
+
+    if not 0 <= parsed <= 1:
+        raise argparse.ArgumentTypeError(f"{field_name} must be between 0 and 1.")
+
+    return parsed
+
+
+def parse_date(value: str) -> str:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("date must use YYYY-MM-DD format, for example 2026-06-05.") from error
+
+    return value
+
+
+def load_rows() -> list[PdmRow]:
+    with DATA_FILE.open(newline="", encoding="utf-8") as data_file:
+        reader = csv.reader(line for line in data_file if line.strip())
+        header = next(reader, None)
+        if header != EXPECTED_HEADER:
+            raise ValueError(f"Expected header {EXPECTED_HEADER}, found {header}.")
+
+        rows: list[PdmRow] = []
+        for row in reader:
+            if len(row) != 3:
+                raise ValueError(f"Expected 3 columns, found {len(row)} in row: {row}")
+            rows.append(PdmRow(row[0], float(row[1]), float(row[2])))
+
+    return rows
+
+
+def save_rows(rows: list[PdmRow]) -> None:
+    sorted_rows = sorted(rows, key=lambda row: row.date)
+    with DATA_FILE.open("w", newline="", encoding="utf-8") as data_file:
+        writer = csv.writer(data_file, lineterminator="\n")
+        writer.writerow(EXPECTED_HEADER)
+        writer.writerows(row.as_csv_row() for row in sorted_rows)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Add or update one row in PDM_Data.txt.")
+    parser.add_argument("date", type=parse_date, help="Data date in YYYY-MM-DD format.")
+    parser.add_argument(
+        "fraction_time_elapsed",
+        type=lambda value: parse_fraction(value, "fraction_time_elapsed"),
+        help="Fiscal-year fraction elapsed, as a decimal from 0 to 1.",
+    )
+    parser.add_argument(
+        "fraction_pdm_spent",
+        type=lambda value: parse_fraction(value, "fraction_PDM_spent"),
+        help="PDM spent fraction, as a decimal from 0 to 1.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    new_row = PdmRow(args.date, args.fraction_time_elapsed, args.fraction_pdm_spent)
+
+    rows_by_date = {row.date: row for row in load_rows()}
+    action = "Updated" if new_row.date in rows_by_date else "Added"
+    rows_by_date[new_row.date] = new_row
+    save_rows(list(rows_by_date.values()))
+
+    print(f"{action} {DATA_FILE.name}: {','.join(new_row.as_csv_row())}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a repeatable, validated command for adding or updating PDM data rows so manual edits are less error-prone. 
- Make it easy to run the same update process on demand or integrate it into scheduled automation later. 

### Description

- Add `scripts/add_pdm_entry.py`, a CLI script that validates the `YYYY-MM-DD` date and fraction values, merges or updates a row by date, sorts rows by date, and writes the canonical CSV with header `date,fraction_time_elapsed,fraction_PDM_spent`.
- The script uses simple CSV reading/writing and argument validation via `argparse` and raises clear errors for malformed input.
- Update `README.md` with usage instructions showing the example command `python scripts/add_pdm_entry.py 2026-06-05 0.6720 0.7010` and guidance on committing and scheduling (cron, Task Scheduler, or GitHub Actions).

### Testing

- Ran `python -m py_compile scripts/add_pdm_entry.py` to verify the script compiles successfully, which passed.
- Ran `python scripts/add_pdm_entry.py --help` to verify the CLI help prints without error, which passed.
- Executed `python scripts/add_pdm_entry.py 2026-05-27 0.6508 0.6838` to verify adding/updating a row and writing the file, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a235e0411dc8330a33b40f4b78ce673)